### PR TITLE
Suggested changes after review

### DIFF
--- a/doc/samples/SqlConnection_AccessTokenCallback.cs
+++ b/doc/samples/SqlConnection_AccessTokenCallback.cs
@@ -18,12 +18,12 @@ class Program
         using (SqlConnection connection = new SqlConnection("Data Source=contoso.database.windows.net;Initial Catalog=AdventureWorks;")
         {
             AccessTokenCallback = async (authParams, cancellationToken) =>
-        {
-            var cred = new DefaultAzureCredential();
-            string scope = authParams.Resource.EndsWith(s_defaultScopeSuffix) ? authParams.Resource : authParams.Resource + s_defaultScopeSuffix;
-            var token = await cred.GetTokenAsync(new TokenRequestContext(new[] { scope }), cancellationToken);
-            return new SqlAuthenticationToken(token.Token, token.ExpiresOn);
-        }
+            {
+                var cred = new DefaultAzureCredential();
+                string scope = authParams.Resource.EndsWith(s_defaultScopeSuffix) ? authParams.Resource : authParams.Resource + s_defaultScopeSuffix;
+                var token = await cred.GetTokenAsync(new TokenRequestContext(new[] { scope }), cancellationToken);
+                return new SqlAuthenticationToken(token.Token, token.ExpiresOn);
+            }
         })
         {
             connection.Open();
@@ -31,4 +31,5 @@ class Program
             Console.WriteLine("State: {0}", connection.State);
         }
     }
+}
 // </Snippet1>

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -4,9 +4,9 @@
 
 // NOTE: The current Microsoft.VSDesigner editor attributes are implemented for System.Data.SqlClient, and are not publicly available.
 // New attributes that are designed to work with Microsoft.Data.SqlClient and are publicly documented should be included in future.
-using System.Threading.Tasks;
-using System.Threading;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 [assembly: System.CLSCompliant(true)]
 namespace Microsoft.Data

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.Designer.cs
@@ -457,20 +457,11 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot set the AccessTokenCallback property if &apos;UserID&apos;, &apos;UID&apos;, &apos;Password&apos;, or &apos;PWD&apos; has been specified in connection string..
+        ///   Looks up a localized string similar to Cannot set the AccessTokenCallback property if &apos;Authentication&apos; has been specified in the connection string..
         /// </summary>
-        internal static string ADP_InvalidMixedUsageOfAccessTokenCallbackAndUserIDPassword {
+        internal static string ADP_InvalidMixedUsageOfAuthenticationAndTokenCallback {
             get {
-                return ResourceManager.GetString("ADP_InvalidMixedUsageOfAccessTokenCallbackAndUserIDPassword", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot set the AccessTokenCallback property if &apos;Authentication=Active Directory Default&apos; has been specified in the connection string..
-        /// </summary>
-        internal static string ADP_InvalidMixedUsageOfActiveDirectoryDefaultTokenAndTokenCallback {
-            get {
-                return ResourceManager.GetString("ADP_InvalidMixedUsageOfActiveDirectoryDefaultTokenAndTokenCallback", resourceCulture);
+                return ResourceManager.GetString("ADP_InvalidMixedUsageOfAuthenticationAndTokenCallback", resourceCulture);
             }
         }
         
@@ -480,15 +471,6 @@ namespace System {
         internal static string ADP_InvalidMixedUsageOfCredentialAndAccessToken {
             get {
                 return ResourceManager.GetString("ADP_InvalidMixedUsageOfCredentialAndAccessToken", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot set the Credential property if the AccessTokenCallback property is already set..
-        /// </summary>
-        internal static string ADP_InvalidMixedUsageOfCredentialAndAccessTokenCallback {
-            get {
-                return ResourceManager.GetString("ADP_InvalidMixedUsageOfCredentialAndAccessTokenCallback", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.resx
@@ -1947,13 +1947,7 @@
   <data name="ADP_InvalidMixedUsageOfAccessTokenCallbackAndIntegratedSecurity" xml:space="preserve">
     <value>Cannot set the AccessTokenCallback property if the 'Integrated Security' connection string keyword has been set to 'true' or 'SSPI'.</value>
   </data>
-  <data name="ADP_InvalidMixedUsageOfAccessTokenCallbackAndUserIDPassword" xml:space="preserve">
-    <value>Cannot set the AccessTokenCallback property if 'UserID', 'UID', 'Password', or 'PWD' has been specified in connection string.</value>
-  </data>
-  <data name="ADP_InvalidMixedUsageOfActiveDirectoryDefaultTokenAndTokenCallback" xml:space="preserve">
-    <value>Cannot set the AccessTokenCallback property if 'Authentication=Active Directory Default' has been specified in the connection string.</value>
-  </data>
-  <data name="ADP_InvalidMixedUsageOfCredentialAndAccessTokenCallback" xml:space="preserve">
-    <value>Cannot set the Credential property if the AccessTokenCallback property is already set.</value>
+  <data name="ADP_InvalidMixedUsageOfAuthenticationAndTokenCallback" xml:space="preserve">
+    <value>Cannot set the AccessTokenCallback property if 'Authentication' has been specified in the connection string.</value>
   </data>
 </root>

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -4,9 +4,9 @@
 
 // NOTE: The current Microsoft.VSDesigner editor attributes are implemented for System.Data.SqlClient, and are not publicly available.
 // New attributes that are designed to work with Microsoft.Data.SqlClient and are publicly documented should be included in future.
-using System.Threading.Tasks;
-using System.Threading;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 [assembly: System.CLSCompliant(true)]
 [assembly: System.Resources.NeutralResourcesLanguageAttribute("en-US")]

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -738,7 +738,7 @@ namespace Microsoft.Data.SqlClient
 
                 _accessToken = value;
                 // Need to call ConnectionString_Set to do proper pool group check
-                ConnectionString_Set(new SqlConnectionPoolKey(_connectionString, _credential, _accessToken, _serverCertificateValidationCallback, _clientCertificateRetrievalCallback, _originalNetworkAddressInfo));
+                ConnectionString_Set(new SqlConnectionPoolKey(_connectionString, _credential, _accessToken, _serverCertificateValidationCallback, _clientCertificateRetrievalCallback, _originalNetworkAddressInfo, null));
             }
         }
 
@@ -759,7 +759,7 @@ namespace Microsoft.Data.SqlClient
                     // Check if the usage of AccessToken has any conflict with the keys used in connection string and credential
                     CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessTokenCallback((SqlConnectionString)ConnectionOptions);
                 }
-                if (value == null)
+                else
                 {
                     throw new ArgumentNullException(nameof(AccessTokenCallback), "Callback cannot be null.");
                 }
@@ -838,16 +838,18 @@ namespace Microsoft.Data.SqlClient
 
                         CheckAndThrowOnInvalidCombinationOfConnectionStringAndSqlCredential(connectionOptions);
                     }
-                    else if (_accessToken != null)
+
+                    if (_accessToken != null)
                     {
                         CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessToken(connectionOptions);
                     }
-                    else if (_accessTokenCallback != null)
+
+                    if (_accessTokenCallback != null)
                     {
                         CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessTokenCallback(connectionOptions);
                     }
                 }
-                ConnectionString_Set(new SqlConnectionPoolKey(value, _credential, _accessToken, _serverCertificateValidationCallback, _clientCertificateRetrievalCallback, _originalNetworkAddressInfo));
+                ConnectionString_Set(new SqlConnectionPoolKey(value, _credential, _accessToken, _serverCertificateValidationCallback, _clientCertificateRetrievalCallback, _originalNetworkAddressInfo, _accessTokenCallback));
                 _connectionString = value;  // Change _connectionString value only after value is validated
                 CacheConnectionStringProperties();
             }
@@ -1184,17 +1186,17 @@ namespace Microsoft.Data.SqlClient
                     }
 
                     CheckAndThrowOnInvalidCombinationOfConnectionStringAndSqlCredential(connectionOptions);
+
                     if (_accessToken != null)
                     {
                         throw ADP.InvalidMixedUsageOfCredentialAndAccessToken();
                     }
-
                 }
 
                 _credential = value;
 
                 // Need to call ConnectionString_Set to do proper pool group check
-                ConnectionString_Set(new SqlConnectionPoolKey(_connectionString, _credential, _accessToken, _serverCertificateValidationCallback, _clientCertificateRetrievalCallback, _originalNetworkAddressInfo));
+                ConnectionString_Set(new SqlConnectionPoolKey(_connectionString, _credential, _accessToken, _serverCertificateValidationCallback, _clientCertificateRetrievalCallback, _originalNetworkAddressInfo, _accessTokenCallback));
             }
         }
 
@@ -1269,20 +1271,9 @@ namespace Microsoft.Data.SqlClient
                 throw ADP.InvalidMixedUsageOfAccessTokenCallbackAndIntegratedSecurity();
             }
 
-            if (UsesActiveDirectoryDefault(connectionOptions))
-            {
-                throw ADP.InvalidMixedUsageOfActiveDirectoryDefaultTokenAndTokenCallback();
-            }
-
             if (UsesAuthentication(connectionOptions))
             {
                 throw ADP.InvalidMixedUsageOfAccessTokenCallbackAndAuthentication();
-            }
-
-            // Check if the usage of AccessToken has the conflict with credential
-            if (_credential != null)
-            {
-                throw ADP.InvalidMixedUsageOfCredentialAndAccessTokenCallback();
             }
 
             if (_accessToken != null)
@@ -2761,7 +2752,7 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.InvalidArgumentLength("newPassword", TdsEnums.MAXLEN_NEWPASSWORD);
                 }
 
-                SqlConnectionPoolKey key = new SqlConnectionPoolKey(connectionString, credential: null, accessToken: null, serverCertificateValidationCallback: null, clientCertificateRetrievalCallback: null, originalNetworkAddressInfo: null);
+                SqlConnectionPoolKey key = new SqlConnectionPoolKey(connectionString, credential: null, accessToken: null, serverCertificateValidationCallback: null, clientCertificateRetrievalCallback: null, originalNetworkAddressInfo: null, accessTokenCallback: null);
 
                 SqlConnectionString connectionOptions = SqlConnectionFactory.FindSqlConnectionOptions(key);
                 if (connectionOptions.IntegratedSecurity || connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryIntegrated)
@@ -2817,7 +2808,7 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.InvalidArgumentLength("newSecurePassword", TdsEnums.MAXLEN_NEWPASSWORD);
                 }
 
-                SqlConnectionPoolKey key = new SqlConnectionPoolKey(connectionString, credential, accessToken: null, serverCertificateValidationCallback: null, clientCertificateRetrievalCallback: null, originalNetworkAddressInfo: null);
+                SqlConnectionPoolKey key = new SqlConnectionPoolKey(connectionString, credential, accessToken: null, serverCertificateValidationCallback: null, clientCertificateRetrievalCallback: null, originalNetworkAddressInfo: null, accessTokenCallback: null);
 
                 SqlConnectionString connectionOptions = SqlConnectionFactory.FindSqlConnectionOptions(key);
 
@@ -2862,7 +2853,7 @@ namespace Microsoft.Data.SqlClient
                     throw SQL.ChangePasswordRequires2005();
                 }
             }
-            SqlConnectionPoolKey key = new SqlConnectionPoolKey(connectionString, credential, accessToken: null, serverCertificateValidationCallback: null, clientCertificateRetrievalCallback: null, originalNetworkAddressInfo: null);
+            SqlConnectionPoolKey key = new SqlConnectionPoolKey(connectionString, credential, accessToken: null, serverCertificateValidationCallback: null, clientCertificateRetrievalCallback: null, originalNetworkAddressInfo: null, accessTokenCallback: null);
 
             SqlConnectionFactory.SingletonInstance.ClearPool(key);
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1598,7 +1598,8 @@ namespace Microsoft.Data.SqlClient
                 || ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryMSI
                 || ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryDefault
                 // Since AD Integrated may be acting like Windows integrated, additionally check _fedAuthRequired
-                || (ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryIntegrated && _fedAuthRequired))
+                || (ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryIntegrated && _fedAuthRequired)
+                || _accessTokenCallback != null)
             {
                 requestedFeatures |= TdsEnums.FeatureExtension.FedAuth;
                 _federatedAuthenticationInfoRequested = true;
@@ -1622,18 +1623,6 @@ namespace Microsoft.Data.SqlClient
                 };
                 // No need any further info from the server for token based authentication. So set _federatedAuthenticationRequested to true
                 _federatedAuthenticationRequested = true;
-            }
-
-            if (_accessTokenCallback != null)
-            {
-                requestedFeatures |= TdsEnums.FeatureExtension.FedAuth;
-                _fedAuthFeatureExtensionData = new FederatedAuthenticationFeatureExtensionData
-                {
-                    libraryType = TdsEnums.FedAuthLibrary.SecurityTokenCallback,
-                    fedAuthRequiredPreLoginResponse = _fedAuthRequired,
-                };
-                // No need any further info from the server for token based authentication. So set _federatedAuthenticationRequested to true
-                _federatedAuthenticationInfoRequested = true;
             }
 
             // The TCE, DATACLASSIFICATION and GLOBALTRANSACTIONS, UTF8 support feature are implicitly requested
@@ -2883,8 +2872,16 @@ namespace Microsoft.Data.SqlClient
                             }
                             else
                             {
-                                authParamsBuilder.WithUserId(ConnectionOptions.UserID);
-                                authParamsBuilder.WithPassword(ConnectionOptions.Password);
+                                if (_credential != null)
+                                {
+                                    username = _credential.UserId;
+                                    authParamsBuilder.WithUserId(username).WithPassword(_credential.Password);
+                                }
+                                else
+                                {
+                                    authParamsBuilder.WithUserId(ConnectionOptions.UserID);
+                                    authParamsBuilder.WithPassword(ConnectionOptions.Password);
+                                }
                                 SqlAuthenticationParameters parameters = authParamsBuilder;
                                 CancellationTokenSource cts = new();
                                 // Use Connection timeout value to cancel token acquire request after certain period of time.(int)
@@ -3054,7 +3051,6 @@ namespace Microsoft.Data.SqlClient
 
                         switch (_fedAuthFeatureExtensionData.libraryType)
                         {
-                            case TdsEnums.FedAuthLibrary.SecurityTokenCallback:
                             case TdsEnums.FedAuthLibrary.MSAL:
                             case TdsEnums.FedAuthLibrary.SecurityToken:
                                 // The server shouldn't have sent any additional data with the ack (like a nonce)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -8656,7 +8656,7 @@ namespace Microsoft.Data.SqlClient
         internal int WriteFedAuthFeatureRequest(FederatedAuthenticationFeatureExtensionData fedAuthFeatureData,
                                                 bool write /* if false just calculates the length */)
         {
-            Debug.Assert(fedAuthFeatureData.libraryType == TdsEnums.FedAuthLibrary.MSAL || fedAuthFeatureData.libraryType == TdsEnums.FedAuthLibrary.SecurityToken || fedAuthFeatureData.libraryType == TdsEnums.FedAuthLibrary.SecurityTokenCallback,
+            Debug.Assert(fedAuthFeatureData.libraryType == TdsEnums.FedAuthLibrary.MSAL || fedAuthFeatureData.libraryType == TdsEnums.FedAuthLibrary.SecurityToken,
                 "only fed auth library type MSAL and Security Token are supported in writing feature request");
 
             int dataLen = 0;
@@ -8665,7 +8665,6 @@ namespace Microsoft.Data.SqlClient
             // set dataLen and totalLen
             switch (fedAuthFeatureData.libraryType)
             {
-                case TdsEnums.FedAuthLibrary.SecurityTokenCallback:
                 case TdsEnums.FedAuthLibrary.MSAL:
                     dataLen = 2;  // length of feature data = 1 byte for library and echo + 1 byte for workflow
                     break;
@@ -8691,7 +8690,6 @@ namespace Microsoft.Data.SqlClient
                 // set upper 7 bits of options to indicate fed auth library type
                 switch (fedAuthFeatureData.libraryType)
                 {
-                    case TdsEnums.FedAuthLibrary.SecurityTokenCallback:
                     case TdsEnums.FedAuthLibrary.MSAL:
                         Debug.Assert(_connHandler._federatedAuthenticationInfoRequested == true, "_federatedAuthenticationInfoRequested field should be true");
                         options |= TdsEnums.FEDAUTHLIB_MSAL << 1;
@@ -8742,7 +8740,14 @@ namespace Microsoft.Data.SqlClient
                                 workflow = TdsEnums.MSALWORKFLOW_ACTIVEDIRECTORYDEFAULT;
                                 break;
                             default:
-                                Debug.Assert(false, "Unrecognized Authentication type for fedauth MSAL request");
+                                if (_connHandler._accessTokenCallback != null)
+                                {
+                                    workflow = TdsEnums.MSALWORKFLOW_ACTIVEDIRECTORYTOKENCREDENTIAL;
+                                }
+                                else
+                                {
+                                    Debug.Assert(false, "Unrecognized Authentication type for fedauth MSAL request");
+                                }
                                 break;
                         }
 
@@ -8751,9 +8756,6 @@ namespace Microsoft.Data.SqlClient
                     case TdsEnums.FedAuthLibrary.SecurityToken:
                         WriteInt(fedAuthFeatureData.accessToken.Length, _physicalStateObj);
                         _physicalStateObj.WriteByteArray(fedAuthFeatureData.accessToken, fedAuthFeatureData.accessToken.Length, 0);
-                        break;
-                    case TdsEnums.FedAuthLibrary.SecurityTokenCallback:
-                        _physicalStateObj.WriteByte(TdsEnums.MSALWORKFLOW_ACTIVEDIRECTORYTOKENCREDENTIAL);
                         break;
                     default:
                         Debug.Assert(false, "Unrecognized FedAuthLibrary type for feature extension request");

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
@@ -934,20 +934,11 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot set the AccessTokenCallback property if &apos;UserID&apos;, &apos;UID&apos;, &apos;Password&apos;, or &apos;PWD&apos; has been specified in connection string..
+        ///   Looks up a localized string similar to Cannot set the AccessTokenCallback property if &apos;Authentication&apos; has been specified in the connection string..
         /// </summary>
-        internal static string ADP_InvalidMixedUsageOfAccessTokenCallbackAndUserIDPassword {
+        internal static string ADP_InvalidMixedUsageOfAuthenticationAndTokenCallback {
             get {
-                return ResourceManager.GetString("ADP_InvalidMixedUsageOfAccessTokenCallbackAndUserIDPassword", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot set the AccessTokenCallback property if &apos;Authentication=Active Directory Default&apos; has been specified in the connection string..
-        /// </summary>
-        internal static string ADP_InvalidMixedUsageOfActiveDirectoryDefaultTokenAndTokenCallback {
-            get {
-                return ResourceManager.GetString("ADP_InvalidMixedUsageOfActiveDirectoryDefaultTokenAndTokenCallback", resourceCulture);
+                return ResourceManager.GetString("ADP_InvalidMixedUsageOfAuthenticationAndTokenCallback", resourceCulture);
             }
         }
         
@@ -957,15 +948,6 @@ namespace System {
         internal static string ADP_InvalidMixedUsageOfCredentialAndAccessToken {
             get {
                 return ResourceManager.GetString("ADP_InvalidMixedUsageOfCredentialAndAccessToken", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot set the Credential property if the AccessTokenCallback property is already set..
-        /// </summary>
-        internal static string ADP_InvalidMixedUsageOfCredentialAndAccessTokenCallback {
-            get {
-                return ResourceManager.GetString("ADP_InvalidMixedUsageOfCredentialAndAccessTokenCallback", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
@@ -4641,13 +4641,7 @@
   <data name="ADP_InvalidMixedUsageOfAccessTokenCallbackAndIntegratedSecurity" xml:space="preserve">
     <value>Cannot set the AccessTokenCallback property if the 'Integrated Security' connection string keyword has been set to 'true' or 'SSPI'.</value>
   </data>
-  <data name="ADP_InvalidMixedUsageOfAccessTokenCallbackAndUserIDPassword" xml:space="preserve">
-    <value>Cannot set the AccessTokenCallback property if 'UserID', 'UID', 'Password', or 'PWD' has been specified in connection string.</value>
-  </data>
-  <data name="ADP_InvalidMixedUsageOfActiveDirectoryDefaultTokenAndTokenCallback" xml:space="preserve">
-    <value>Cannot set the AccessTokenCallback property if 'Authentication=Active Directory Default' has been specified in the connection string.</value>
-  </data>
-  <data name="ADP_InvalidMixedUsageOfCredentialAndAccessTokenCallback" xml:space="preserve">
-    <value>Cannot set the Credential property if the AccessTokenCallback property is already set.</value>
+  <data name="ADP_InvalidMixedUsageOfAuthenticationAndTokenCallback" xml:space="preserve">
+    <value>Cannot set the AccessTokenCallback property if 'Authentication' has been specified in the connection string.</value>
   </data>
 </root>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -1273,19 +1273,10 @@ namespace Microsoft.Data.Common
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndTokenCallback));
 
         internal static Exception InvalidMixedUsageOfAccessTokenCallbackAndAuthentication()
-            => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndTokenCallback));
+            => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAuthenticationAndTokenCallback));
 
         internal static Exception InvalidMixedUsageOfAccessTokenCallbackAndIntegratedSecurity()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenCallbackAndIntegratedSecurity));
-
-        internal static Exception InvalidMixedUsageOfAccessTokenCallbackAndUserIDPassword()
-            => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenCallbackAndUserIDPassword));
-
-        internal static Exception InvalidMixedUsageOfCredentialAndAccessTokenCallback()
-            => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfCredentialAndAccessTokenCallback));
-
-        internal static Exception InvalidMixedUsageOfActiveDirectoryDefaultTokenAndTokenCallback()
-            => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfActiveDirectoryDefaultTokenAndTokenCallback));
         #endregion
 
         internal static bool IsEmpty(string str) => string.IsNullOrEmpty(str);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Data.SqlClient
                             SqlClientOriginalNetworkAddressInfo originalNetworkAddressInfo,
                             Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> accessTokenCallback = null) : base(connectionString)
         {
-            Debug.Assert(_credential == null || _accessToken == null || accessTokenCallback == null, "Credential, AccessToken, and Callback can't have the value at the same time.");
+            Debug.Assert(_credential == null || _accessToken == null || accessTokenCallback == null, "Credential, AccessToken, and Callback can't have a value at the same time.");
             _credential = credential;
             _accessToken = accessToken;
             _accessTokenCallback = accessTokenCallback;
@@ -68,9 +68,9 @@ namespace Microsoft.Data.SqlClient
         #endregion
 #else
         #region NET Core
-        internal SqlConnectionPoolKey(string connectionString, SqlCredential credential, string accessToken, Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> accessTokenCallback = null) : base(connectionString)
+        internal SqlConnectionPoolKey(string connectionString, SqlCredential credential, string accessToken, Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> accessTokenCallback) : base(connectionString)
         {
-            Debug.Assert(credential == null || accessToken == null || accessTokenCallback == null, "Credential, AccessToken, and Callback can't have the value at the same time.");
+            Debug.Assert(credential == null || accessToken == null || accessTokenCallback == null, "Credential, AccessToken, and Callback can't have a value at the same time.");
             _credential = credential;
             _accessToken = accessToken;
             _accessTokenCallback = accessTokenCallback;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -255,7 +255,6 @@ namespace Microsoft.Data.SqlClient
         public const byte FEDAUTHLIB_LIVEID = 0X00;
         public const byte FEDAUTHLIB_SECURITYTOKEN = 0x01;
         public const byte FEDAUTHLIB_MSAL = 0x02;
-        public const byte FEDAUTHLIB_SECURITYTOKEN_CALLBACK = 0x03;
         public const byte FEDAUTHLIB_RESERVED = 0X7F;
 
         public enum FedAuthLibrary : byte
@@ -263,8 +262,7 @@ namespace Microsoft.Data.SqlClient
             LiveId = FEDAUTHLIB_LIVEID,
             SecurityToken = FEDAUTHLIB_SECURITYTOKEN,
             MSAL = FEDAUTHLIB_MSAL,
-            Default = FEDAUTHLIB_RESERVED,
-            SecurityTokenCallback = FEDAUTHLIB_SECURITYTOKEN_CALLBACK
+            Default = FEDAUTHLIB_RESERVED
         }
 
         public const byte MSALWORKFLOW_ACTIVEDIRECTORYPASSWORD = 0x01;

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -7,6 +7,8 @@ using System.Data;
 using System.Data.Common;
 using System.Reflection;
 using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.SqlServer.TDS.Servers;
 using Xunit;
 
@@ -186,6 +188,85 @@ namespace Microsoft.Data.SqlClient.Tests
             var conn = new SqlConnection(string.Empty, sqlCredential);
 
             Assert.Equal(sqlCredential, conn.Credential);
+        }
+
+        [Fact]
+        public void ConnectionTestAccessTokenCallbackCombinations()
+        {
+            var cleartextCredsConnStr = "User=test;Password=test;";
+            var sspiConnStr = "Integrated Security=true;";
+            var authConnStr = "Authentication=ActiveDirectoryPassword";
+            var testPassword = new SecureString();
+            testPassword.MakeReadOnly();
+            var sqlCredential = new SqlCredential(string.Empty, testPassword);
+            Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> callback = (ctx, token) =>
+                    Task.FromResult(new SqlAuthenticationToken("invalid", DateTimeOffset.MaxValue));
+
+            // Successes
+            using (var conn = new SqlConnection(cleartextCredsConnStr))
+            {
+                conn.AccessTokenCallback = callback;
+            }
+
+            using (var conn = new SqlConnection(string.Empty, sqlCredential))
+            {
+                conn.AccessTokenCallback = callback;
+            }
+
+            using (var conn = new SqlConnection()
+            {
+                AccessTokenCallback = callback
+            })
+            {
+                conn.Credential = sqlCredential;
+            }
+
+            using (var conn = new SqlConnection()
+            {
+                AccessTokenCallback = callback
+            })
+            {
+                conn.ConnectionString = cleartextCredsConnStr;
+            }
+
+            //Failures
+            using (var conn = new SqlConnection(sspiConnStr))
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    conn.AccessTokenCallback = callback;
+                });
+            }
+
+            using (var conn = new SqlConnection(authConnStr))
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    conn.AccessTokenCallback = callback;
+                });
+            }
+
+            using (var conn = new SqlConnection()
+            {
+                AccessTokenCallback = callback
+            })
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    conn.ConnectionString = sspiConnStr;
+                });
+            }
+
+            using (var conn = new SqlConnection()
+            {
+                AccessTokenCallback = callback
+            })
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    conn.ConnectionString = authConnStr;
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
Allow credential with callback and pass to the callback, if available
Don't allow Authentication option with callback
Map to the correct FEDAUTHLIB_MSAL value
Add functional tests for connection options
Ensure callback is correctly set on the pool key in all cases
Other minor adjustments